### PR TITLE
fix: support dynamic markers with position alias

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -52,13 +52,29 @@ Common events: `@click`, `@add`, `@remove`, `@popupopen`, `@tooltipopen`.
 
 ### `LMarker`
 
-| Prop      | Type               | Required | Description                                                                                         |
-| --------- | ------------------ | -------- | --------------------------------------------------------------------------------------------------- |
-| `id`      | `string`           | Yes      | Marker id used by nested popup and tooltip components.                                              |
-| `latlng`  | `LatLngExpression` | Yes      | Marker position.                                                                                    |
-| `options` | `MarkerOptions`    | No       | Options passed to `L.marker`; `icon`, `opacity`, `zIndexOffset`, and `draggable` update reactively. |
+| Prop       | Type               | Required | Description                                                                                         |
+| ---------- | ------------------ | -------- | --------------------------------------------------------------------------------------------------- |
+| `id`       | `string`           | Yes      | Marker id used by nested popup and tooltip components.                                              |
+| `latlng`   | `LatLngExpression` | No       | Marker position. Required unless `position` is provided.                                            |
+| `position` | `LatLngExpression` | No       | Alias for `latlng`, kept for compatibility with older examples.                                     |
+| `options`  | `MarkerOptions`    | No       | Options passed to `L.marker`; `icon`, `opacity`, `zIndexOffset`, and `draggable` update reactively. |
 
 Common events: `@click`, `@dragstart`, `@drag`, `@dragend`, `@move`, `@popupopen`, `@tooltipopen`.
+
+Dynamic marker lists can start empty and add markers later:
+
+```vue
+<template>
+  <LMarker
+    v-for="(params, user) in points"
+    :id="user"
+    :key="user"
+    :position="params.pos"
+  >
+    <LTooltip :options="{ content: user }" />
+  </LMarker>
+</template>
+```
 
 ### `LPopup`
 

--- a/src/components/LMarker.vue
+++ b/src/components/LMarker.vue
@@ -2,6 +2,7 @@
 import L, { type LatLngExpression, type MarkerOptions } from 'leaflet';
 import {
   type PropType,
+  computed,
   nextTick,
   onBeforeUnmount,
   provide,
@@ -28,8 +29,12 @@ const props = defineProps({
     required: true,
   },
   latlng: {
-    type: Object as PropType<LatLngExpression>,
-    required: true,
+    type: [Object, Array] as PropType<LatLngExpression>,
+    required: false,
+  },
+  position: {
+    type: [Object, Array] as PropType<LatLngExpression>,
+    required: false,
   },
   options: {
     type: Object as PropType<MarkerOptions>,
@@ -48,19 +53,37 @@ const attrs = useAttrs();
 let marker: L.Marker | null = null;
 let unbindEvents: (() => void) | undefined;
 
-nextTick(() => {
+const markerLatLng = computed(() => props.latlng ?? props.position);
+
+const createMarker = (latlng: LatLngExpression) => {
+  if (marker) return;
+
   fixImageUrl();
-  marker = L.marker(props.latlng, props.options);
+  marker = L.marker(latlng, props.options);
   unbindEvents = bindLeafletEventsFromAttrs(marker, attrs, markerEvents);
 
   markerProvide.setMarker(markerKey, marker);
   layerProvider?.addLayer(marker);
+};
+
+nextTick(() => {
+  const latlng = markerLatLng.value;
+  if (latlng) {
+    createMarker(latlng);
+  }
 });
 
 watch(
-  () => props.latlng,
+  markerLatLng,
   (latlng) => {
-    marker?.setLatLng(latlng);
+    if (!latlng) return;
+
+    if (marker) {
+      marker.setLatLng(latlng);
+      return;
+    }
+
+    createMarker(latlng);
   },
   { deep: true }
 );
@@ -78,6 +101,7 @@ onBeforeUnmount(() => {
   if (marker) {
     layerProvider?.removeLayer(marker);
   }
+  markerProvide.removeMarker(markerKey);
 });
 
 defineExpose({

--- a/src/components/existingComponentsLifecycle.test.ts
+++ b/src/components/existingComponentsLifecycle.test.ts
@@ -1,10 +1,11 @@
 import { mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { nextTick } from 'vue';
+import { defineComponent, nextTick, ref } from 'vue';
 import {
   LEAFLET_LAYER_PROVIDER,
   type LeafletLayerProvider,
 } from '../core/Layer';
+import { markerProvide } from '../core/Marker';
 import LMarker from './LMarker.vue';
 import LPolyline from './LPolyline.vue';
 import LTilelayer from './LTilelayer.vue';
@@ -74,6 +75,85 @@ describe('existing component lifecycle', () => {
     wrapper.unmount();
 
     expect(provider.removeLayer).toHaveBeenCalledWith(marker);
+    expect(markerProvide.getMarker('marker-pin')).toBeNull();
+  });
+
+  it('supports position as a marker location alias', async () => {
+    const provider = createProvider();
+    const wrapper = mount(LMarker, {
+      props: {
+        id: 'pin',
+        position: [0, 0],
+      },
+      global: {
+        provide: {
+          [LEAFLET_LAYER_PROVIDER]: provider,
+        },
+      },
+    });
+
+    await nextTick();
+
+    expect(leafletMocks.marker).toHaveBeenCalledWith([0, 0], undefined);
+
+    const marker = leafletMocks.marker.mock.results[0].value;
+    await wrapper.setProps({ position: [1, 1] });
+
+    expect(marker.setLatLng).toHaveBeenCalledWith([1, 1]);
+
+    wrapper.unmount();
+  });
+
+  it('adds markers that are created after a dynamic list starts empty', async () => {
+    const provider = createProvider();
+    const Host = defineComponent({
+      components: { LMarker },
+      setup() {
+        const points = ref<Record<string, { pos: [number, number] }>>({});
+        return { points };
+      },
+      template: `
+        <LMarker
+          v-for="(params, user) in points"
+          :id="user"
+          :key="user"
+          :position="params.pos"
+        />
+      `,
+    });
+
+    const wrapper = mount(Host, {
+      global: {
+        provide: {
+          [LEAFLET_LAYER_PROVIDER]: provider,
+        },
+      },
+    });
+
+    await nextTick();
+    expect(leafletMocks.marker).not.toHaveBeenCalled();
+
+    wrapper.vm.points = {
+      alice: { pos: [51.505, -0.09] },
+      bob: { pos: [51.508, -0.11] },
+    };
+    await nextTick();
+    await nextTick();
+
+    expect(leafletMocks.marker).toHaveBeenCalledTimes(2);
+    expect(leafletMocks.marker).toHaveBeenNthCalledWith(
+      1,
+      [51.505, -0.09],
+      undefined
+    );
+    expect(leafletMocks.marker).toHaveBeenNthCalledWith(
+      2,
+      [51.508, -0.11],
+      undefined
+    );
+    expect(provider.addLayer).toHaveBeenCalledTimes(2);
+
+    wrapper.unmount();
   });
 
   it('removes vector layers from their provider on unmount', async () => {

--- a/src/core/Marker.test.ts
+++ b/src/core/Marker.test.ts
@@ -15,4 +15,13 @@ describe('markerProvide', () => {
     expect(markerProvide.getMarker('marker-main')).toEqual(marker);
     expect(markerProvide.marker.value['marker-main']).toEqual(marker);
   });
+
+  it('removes markers by key', () => {
+    const marker = { id: 'leaflet-marker' } as unknown as Marker;
+
+    markerProvide.setMarker('marker-removable', marker);
+    markerProvide.removeMarker('marker-removable');
+
+    expect(markerProvide.getMarker('marker-removable')).toBeNull();
+  });
 });

--- a/src/core/Marker.ts
+++ b/src/core/Marker.ts
@@ -14,10 +14,15 @@ const setMarker = (key: string, content: Marker) => {
   marker.value[key] = content;
 };
 
+const removeMarker = (key: string) => {
+  delete marker.value[key];
+};
+
 export const markerProvide = {
   marker,
   getMarker,
   setMarker,
+  removeMarker,
 };
 
 export type MarkerProvide = typeof markerProvide;


### PR DESCRIPTION
## Summary

- Support `position` as a compatibility alias for `LMarker` coordinates while preserving `latlng`.
- Add regression coverage for marker lists that start empty and add markers later.
- Remove marker registry entries when markers unmount, and document the dynamic marker pattern.

Closes #12

## Validation

- `pnpm format:check`
- `pnpm test`
- `pnpm build:example`
- `pnpm check:dist`